### PR TITLE
eye toggle for password fields in login and signup

### DIFF
--- a/client/src/components/login-form.tsx
+++ b/client/src/components/login-form.tsx
@@ -15,13 +15,14 @@ import {
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Link } from "react-router-dom"
-import { Github } from "lucide-react"
+import { Github, Eye, EyeOff } from "lucide-react" //for password visibility toggle
 
 import { useAuthStore } from "@/store/auth-store"
 import { useNavigate } from "react-router-dom"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { loginSchema, type LoginFormData } from "@/schemas/authSchema"
+import { useState } from "react"
 
 export function LoginForm({
   className,
@@ -42,6 +43,8 @@ export function LoginForm({
       password: "",
     },
   })
+  const [showPassword, setShowPassword] = useState(false)
+
 
   const onSubmit = async (data: LoginFormData) => {
     try {
@@ -88,14 +91,31 @@ export function LoginForm({
                     Forgot your password?
                   </a>
                 </div>
-                <Input
-                  id="password"
-                  type="password"
-                  {...register("password")}
-                />
+                <div className="relative">
+                  <Input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    required
+                    {...register("password")}
+                    aria-describedby="password-visibility"
+                  />
+                  <span id="password-visibility" className="sr-only">
+                    {showPassword ? "Hide password" : "Show password"}
+                  </span>
+                  <button
+                    type="button"
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
+                    onClick={() => setShowPassword((s: boolean) => !s)}
+                    className="absolute inset-y-0 right-2 flex items-center p-1 text-slate-500 hover:text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-md"
+                  >
+                    {showPassword ? <Eye size={16} /> : <EyeOff size={16} />}
+                  </button>
+                </div>
                 {errors.password && (
                   <p className="text-red-500 text-xs mt-1">{errors.password.message}</p>
                 )}
+
               </Field>
 
               {/* Display server-side errors from Zustand */}
@@ -118,6 +138,6 @@ export function LoginForm({
           </form>
         </CardContent>
       </Card>
-    </div>
+    </div >
   )
 }

--- a/client/src/components/signup-form.tsx
+++ b/client/src/components/signup-form.tsx
@@ -16,13 +16,16 @@ import {
   FieldLabel,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { Github } from "lucide-react";
+import { Github, Eye, EyeOff } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuthStore } from "@/store/auth-store";
+import { useState } from "react";
 
 export function SignupForm({ ...props }: React.ComponentProps<typeof Card>) {
   const { signup, isLoading, error: serverError } = useAuthStore();
   const navigate = useNavigate();
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const {
     register,
@@ -94,7 +97,7 @@ export function SignupForm({ ...props }: React.ComponentProps<typeof Card>) {
                 {...register("email")}
               />
               {errors.email ? (
-                 <p className="text-red-500 text-xs mt-1">{errors.email.message}</p>
+                <p className="text-red-500 text-xs mt-1">{errors.email.message}</p>
               ) : (
                 <FieldDescription className="text-left text-xs">
                   We&apos;ll use this to contact you. We will not share your email with anyone else.
@@ -105,13 +108,28 @@ export function SignupForm({ ...props }: React.ComponentProps<typeof Card>) {
             {/* Password */}
             <Field>
               <FieldLabel htmlFor="password">Password</FieldLabel>
-              <Input
-                id="password"
-                type="password"
-                {...register("password")}
-              />
+              <div className="relative">
+                <Input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  {...register("password")}
+                  aria-describedby="password-visibility"
+                />
+                <span id="password-visibility" className="sr-only">
+                  {showPassword ? "Hide password" : "Show password"}
+                </span>
+                <button
+                  type="button"
+                  aria-label="Toggle password visibility"
+                  aria-pressed={showPassword}
+                  onClick={() => setShowPassword((s) => !s)}
+                  className="absolute inset-y-0 right-2 flex items-center p-1 text-slate-500 hover:text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-md"
+                >
+                  {showPassword ? <Eye size={16} /> : <EyeOff size={16} />}
+                </button>
+              </div>
               {errors.password ? (
-                 <p className="text-red-500 text-xs mt-1">{errors.password.message}</p>
+                <p className="text-red-500 text-xs mt-1">{errors.password.message}</p>
               ) : (
                 <FieldDescription className="text-left">
                   Must be at least 8 characters long.
@@ -122,14 +140,30 @@ export function SignupForm({ ...props }: React.ComponentProps<typeof Card>) {
             {/* Confirm Password */}
             <Field>
               <FieldLabel htmlFor="confirmPassword">Confirm Password</FieldLabel>
-              <Input
-                id="confirmPassword"
-                type="password"
-                {...register("confirmPassword")}
-              />
+              <div className="relative">
+                <Input
+                  id="confirmPassword"
+                  type={showConfirmPassword ? "text" : "password"}
+                  {...register("confirmPassword")}
+                  aria-describedby="confirm-password-visibility"
+                />
+                <span id="confirm-password-visibility" className="sr-only">
+                  {showConfirmPassword ? "Hide password" : "Show password"}
+                </span>
+                <button
+                  type="button"
+                  aria-label="Toggle confirm password visibility"
+                  aria-pressed={showConfirmPassword}
+                  onClick={() => setShowConfirmPassword((s) => !s)}
+                  className="absolute inset-y-0 right-2 flex items-center p-1 text-slate-500 hover:text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-md"
+                >
+                  {showConfirmPassword ? <Eye size={16} /> : <EyeOff size={16} />}
+                </button>
+              </div>
               {errors.confirmPassword && (
                 <p className="text-red-500 text-xs mt-1">{errors.confirmPassword.message}</p>
               )}
+              <FieldDescription className="text-left">Please confirm your password.</FieldDescription>
             </Field>
 
             {/* Server Errors from Zustand Store */}


### PR DESCRIPTION
# 🚀 Pull Request

Thank you for your contribution! Please fill out the information below before submitting your PR.

---

## 📌 What does this PR do?
Adds accessible password visibility toggles to the Sign In and Sign Up forms. Each password field now shows an eye icon (using lucide-react) inside the input; clicking or keyboard-activating the icon toggles the input between type="password" and type="text".

---

## 🔗 Related Issue
N/A

---

## 🛠️ Type of Change
Please check the relevant option:
- [ ] Bug fix 🐞
- [x] New feature 🚀
- [x] UI/UX improvement 🎨
- [ ] Documentation update 📚
- [ ] Refactor ♻️
- [ ] Other

---

## ✅ Checklist
Please ensure all the following are completed:

- [x] My code follows the project’s coding standards
- [x] I have tested my changes locally
- [x] No API keys or secrets are committed
- [x] Existing functionality is not broken
- [x] I have added comments where necessary
- [x] I have updated documentation if required

---

## 🧪 Testing Details
Started the dev server 
Visually verified on Sign In and Sign Up pages:
Eye icon appears inside password inputs.
Clicking the icon toggles visibility (open eye = visible, closed eye = hidden).
Toggling switches input type between "password" and "text".

---

## 🖼️ Screenshots (if UI changes)
<img width="463" height="811" alt="image" src="https://github.com/user-attachments/assets/54ebb9c6-35a4-4a5b-be5e-f5851c4b55a3" />
<img width="423" height="427" alt="image" src="https://github.com/user-attachments/assets/bd1a7b5b-3903-4172-92b2-3015a900cee9" />
<img width="444" height="431" alt="image" src="https://github.com/user-attachments/assets/0e6c1e8b-1887-41c4-b47b-33ecda715c3e" />

---

## 💬 Additional Notes
Any additional information for reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login form now includes a password visibility toggle so users can show or hide their password while entering credentials.
  * Signup form now includes visibility toggles for both password and confirm password fields to help users verify their entries.

* **Accessibility**
  * Toggle controls include accessible labels and descriptions; confirm-password field includes additional descriptive help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->