### PR TITLE
Implement Add Task Button

### DIFF
--- a/client/src/components/TaskColumn.tsx
+++ b/client/src/components/TaskColumn.tsx
@@ -78,16 +78,6 @@ export function TaskColumn({
           )}
         </button>
       )}
-
-      {hasWriteAccess && (
-        <button
-          onClick={() => onAddTask(status)}
-          className="mt-2 w-full flex items-center justify-center gap-2 py-2.5 text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-500/10 rounded-xl transition-colors"
-        >
-          <Plus className="w-4 h-4" />
-          Add task
-        </button>
-      )}
     </div>
   );
 }

--- a/client/src/pages/BoardView.tsx
+++ b/client/src/pages/BoardView.tsx
@@ -8,7 +8,7 @@ import type { DropResult } from '@hello-pangea/dnd';
 import { TaskModal } from '../components/TaskModal';
 import type { TaskProps } from '../components/TaskModal';
 import { Button } from '../components/ui/button';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Plus } from 'lucide-react';
 
 // Column type definition
 type ColumnStatus = 'todo' | 'in-progress' | 'review' | 'done';
@@ -307,6 +307,15 @@ export default function BoardView() {
             </div>
           </div>
         </div>
+        {hasWriteAccess && (
+          <Button
+            onClick={() => handleOpenCreateModal('todo')}
+            className="gap-2"
+          >
+            <Plus className="w-4 h-4" />
+            Add Task
+          </Button>
+        )}
       </div>
 
       {/* Kanban Board */}


### PR DESCRIPTION
## 📌 What does this PR do?

Consolidates 4 "Add Task" buttons from columns into a single button in the top-right header.

## 🔗 Related Issue

Fixes #61

## 🛠️ Type of Change

- [x] UI/UX improvement 🎨

## ✅ Checklist

- [x] Code follows project standards
- [x] Tested locally
- [x] No breaking changes

## 🧪 Testing Details
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/6feadc26-d947-4d93-861d-68bb3383b3a9" />

## 💬 Additional Notes

Minimal change: 2 files modified, no new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * The Add task button has been moved from individual task columns to the main board header.
  * Clicking the button opens a task creation modal (accessible only to users with write permissions).
  * New tasks created through the modal are automatically assigned a default status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->